### PR TITLE
feat: DockerfileにBunランタイムを追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,65 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Node.js
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Bun
+bun.lockb
+.bun
+
+# TypeScript
+*.tsbuildinfo
+dist
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Testing
+coverage
+.nyc_output
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Logs
+logs
+*.log
+
+# Documentation
+docs
+*.md
+!README.md
+
+# CI/CD
+.github
+.gitlab-ci.yml
+.circleci
+
+# Docker
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# Cache
+.cache
+.agents-cache
+.agents-history
+
+# Temporary files
+tmp
+temp
+*.tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN apt-get update && apt-get install -y  --no-install-recommends \
 # npmを最新バージョンに更新
 RUN npm install -g npm@latest
 
+# Bunのインストール
+RUN curl -fsSL https://bun.sh/install | bash
+ENV BUN_INSTALL="/root/.bun"
+ENV PATH="$BUN_INSTALL/bin:$PATH"
+
 # pnpmとClaude Codeのインストール（最新バージョン）
 RUN npm install -g pnpm@latest @anthropic-ai/claude-code@latest
 


### PR DESCRIPTION
## 概要
DockerコンテナでBunランタイムを使用できるようにしました。

## 変更内容
- DockerfileにBunのインストール手順を追加
- BUN_INSTALLとPATH環境変数を設定
- .dockerignoreファイルを作成

🤖 Generated with [Claude Code](https://claude.ai/code)