### PR TITLE
refactor: 開発環境をBunに統一

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,16 +32,12 @@ RUN curl -fsSL https://bun.sh/install | bash
 ENV BUN_INSTALL="/root/.bun"
 ENV PATH="$BUN_INSTALL/bin:$PATH"
 
-# pnpmとClaude Codeのインストール（最新バージョン）
-RUN npm install -g pnpm@latest @anthropic-ai/claude-code@latest
-
-# pnpmの環境変数設定
-ENV PNPM_HOME=/pnpm
-ENV PATH="$PNPM_HOME:$PATH"
+# Claude Codeのインストール（最新バージョン）
+RUN bun add -g @anthropic-ai/claude-code@latest
 
 # グローバルNode.jsツールのインストール（必要に応じて追加）
- RUN pnpm add -g \
-     @google/gemini-cli@latest \
+RUN bun add -g \
+     @google/gemini-cli@latest
 #     @aws-amplify/cli@latest \
 #     eslint@latest \
 #     prettier@latest
@@ -60,8 +56,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | g
 # ログディレクトリの作成
 RUN mkdir -p /147-Xyla/.logs
 
-# pnpmのグローバルストアを設定（コンテナ内でキャッシュ）
-RUN pnpm config set store-dir /pnpm-store
+# Bunのグローバルインストールディレクトリを設定
+RUN bun config set install.globalDir /bun-global
 
 # エントリーポイントスクリプトをコピー
 COPY scripts/entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@
 ## インストール
 
 ```bash
-# Bunを使用したグローバルインストール
-bun install -g @akiojin/agents
+# Bunを使用したグローバルインストール（推奨）
+bun add -g @akiojin/agents
 
-# または npx/bunx で直接実行
+# または bunx で直接実行
 bunx @akiojin/agents
+
+# npmを使用する場合
+npm install -g @akiojin/agents
 ```
 
 ## 使い方
@@ -131,6 +134,26 @@ mcpServers:
 
 プロジェクトへの貢献を歓迎します！
 
+### 開発環境のセットアップ
+
+```bash
+# リポジトリのクローン
+git clone https://github.com/akiojin/agents.git
+cd agents
+
+# 依存関係のインストール（Bun推奨）
+bun install
+
+# 開発モードで実行
+bun run dev
+
+# ビルド
+bun run build
+
+# テスト
+bun test
+```
+
 ### 開発フロー
 
 Git Flow に従って開発を行います：
@@ -151,8 +174,7 @@ Git Flow に従って開発を行います：
 
 ## 必要要件
 
-- Bun v1.0以上
-- Node.js v18以上（互換性のため）
+- Bun v1.0以上（推奨）または Node.js v18以上
 - Git
 
 ## ライセンス


### PR DESCRIPTION
## 概要
開発環境をBunランタイムに統一しました。

## 変更内容
- DockerfileをBunに置き換え
- グローバルツールのインストールをBunで実行
- READMEのインストール手順をBun中心に更新
- 開発環境セットアップ手順を追加

## 動作確認
- [ ] Dockerコンテナのビルド確認
- [ ] Bunでの依存関係インストール確認
- [ ] CLIコマンドの実行確認

🤖 Generated with [Claude Code](https://claude.ai/code)