### PR TITLE
fix: Bunの未実装configコマンドを削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,6 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | g
 # ログディレクトリの作成
 RUN mkdir -p /147-Xyla/.logs
 
-# Bunのグローバルインストールディレクトリを設定
-RUN bun config set install.globalDir /bun-global
-
 # エントリーポイントスクリプトをコピー
 COPY scripts/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## 概要
DockerビルドエラーをBunの未実装コマンドを削除して修正

## 問題
Bunの`config`コマンドはまだ実装されていないため、Dockerビルドでエラーが発生

## 修正内容
- Dockerfileから`bun config set install.globalDir`コマンドを削除

🤖 Generated with [Claude Code](https://claude.ai/code)