### PR TITLE
fix: initコマンドのプロバイダー値マッピング修正

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,20 +53,25 @@ program
           type: 'list',
           name: 'provider',
           message: 'LLMプロバイダーを選択:',
-          choices: ['OpenAI', 'Anthropic', 'Local (GPT-OSS)', 'Local (LM Studio)'],
+          choices: [
+            { name: 'OpenAI', value: 'openai' },
+            { name: 'Anthropic', value: 'anthropic' },
+            { name: 'Local (GPT-OSS)', value: 'local-gptoss' },
+            { name: 'Local (LM Studio)', value: 'local-lmstudio' },
+          ],
         },
         {
           type: 'input',
           name: 'apiKey',
           message: 'APIキーを入力（ローカルの場合は空欄）:',
-          when: (answers: InitAnswers) => !answers.provider.includes('Local'),
+          when: (answers: InitAnswers) => !answers.provider.startsWith('local-'),
         },
         {
           type: 'input',
           name: 'localEndpoint',
           message: 'ローカルエンドポイントURL:',
           default: 'http://localhost:8080',
-          when: (answers: InitAnswers) => answers.provider.includes('Local'),
+          when: (answers: InitAnswers) => answers.provider.startsWith('local-'),
         },
         {
           type: 'confirm',


### PR DESCRIPTION
## 概要
initコマンドでプロバイダー選択時の表示名と内部値の不整合を修正

## 問題
- 表示名「Local (LM Studio)」が選択されても、内部値「local-lmstudio」に正しくマッピングされずZodバリデーションエラーが発生
- when条件でローカル判定が不正確

## 修正内容
- ✅ プロバイダー選択肢をname/value形式に変更
- ✅ when条件をstartsWith('local-')に修正
- ✅ 2つのローカルオプションを明確に区別:
  - Local (GPT-OSS) → local-gptoss
  - Local (LM Studio) → local-lmstudio

## テスト
- ✅ TypeScript: エラー0個
- ✅ ビルド: 成功
- ✅ initコマンド: プロバイダー値正常マッピング確認

🤖 Generated with [Claude Code](https://claude.ai/code)